### PR TITLE
Optimize lineToANSI

### DIFF
--- a/output.go
+++ b/output.go
@@ -282,6 +282,8 @@ func lineToANSI(parts []screenLine, current ...style) (string, style) {
 		styles := s.ANSITransform(previous)
 		fromZero := s.ANSITransform(style(0))
 		if joinedLength(fromZero)+1 < joinedLength(styles) {
+			// It's shorter to reset and then set the styles we want rather than
+			// transforming from the previous style.
 			styles = append([]string{""}, fromZero...)
 		}
 		lineBuf.appendANSIStyle(styles)

--- a/output.go
+++ b/output.go
@@ -280,11 +280,14 @@ func lineToANSI(parts []screenLine, current ...style) (string, style) {
 			s = (previous &^ (sbBGColorX | sbBGColor)) | (s & (sbBGColorX | sbBGColor))
 		}
 		styles := s.ANSITransform(previous)
-		fromZero := s.ANSITransform(style(0))
-		if joinedLength(fromZero)+1 < joinedLength(styles) {
-			// It's shorter to reset and then set the styles we want rather than
-			// transforming from the previous style.
-			styles = append([]string{""}, fromZero...)
+		if previous != 0 && len(styles) > 0 {
+			// If there was a style previously, and there is a new style to
+			// apply, see if it's shorter to reset and then apply the new style
+			// rather than transforming from the previous style.
+			fromZero := s.ANSITransform(style(0))
+			if joinedLength(fromZero)+1 < joinedLength(styles) {
+				styles = append([]string{""}, fromZero...)
+			}
 		}
 		lineBuf.appendANSIStyle(styles)
 		lineBuf.WriteRune(n.blob)

--- a/output.go
+++ b/output.go
@@ -285,6 +285,8 @@ func lineToANSI(parts []screenLine, current ...style) (string, style) {
 			// apply, see if it's shorter to reset and then apply the new style
 			// rather than transforming from the previous style.
 			fromZero := s.ANSITransform(style(0))
+			// If we are to apply to fromZero styles, we will need to prefix
+			// them with a reset code, so add 1 to the length.
 			if joinedLength(fromZero)+1 < joinedLength(styles) {
 				styles = append([]string{""}, fromZero...)
 			}

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -538,32 +538,32 @@ var asANSITestCases = []struct {
 	want  string
 }{
 	{
-		name:  "test plain text",
+		name: "test plain text",
 		input: []screenLine{
 			{
 				nodes: []node{
 					{
-						blob: '0',
+						blob:  '0',
 						style: style(0),
 					},
 					{
-						blob: '1',
+						blob:  '1',
 						style: style(0),
 					},
 					{
-						blob: '2',
+						blob:  '2',
 						style: style(0),
 					},
 					{
-						blob: '3',
+						blob:  '3',
 						style: style(0),
 					},
 					{
-						blob: '4',
+						blob:  '4',
 						style: style(0),
 					},
 					{
-						blob: '5',
+						blob:  '5',
 						style: style(0),
 					},
 				},
@@ -573,39 +573,39 @@ var asANSITestCases = []struct {
 		want: "012345\n",
 	},
 	{
-		name:  "test single blank line",
+		name: "test single blank line",
 		input: []screenLine{
 			{
-				nodes: make([]node, 0),
+				nodes:   make([]node, 0),
 				newline: true,
 			},
 			{
-				nodes: make([]node, 0),
+				nodes:   make([]node, 0),
 				newline: false,
 			},
 		},
 		want: "\n",
 	},
 	{
-		name:  "test two blank lines",
+		name: "test two blank lines",
 		input: []screenLine{
 			{
-				nodes: make([]node, 0),
+				nodes:   make([]node, 0),
 				newline: true,
 			},
 			{
-				nodes: make([]node, 0),
+				nodes:   make([]node, 0),
 				newline: true,
 			},
 			{
-				nodes: make([]node, 0),
+				nodes:   make([]node, 0),
 				newline: false,
 			},
 		},
 		want: "\n\n",
 	},
 	{
-		name:  "test new lines",
+		name: "test new lines",
 		input: []screenLine{
 			{
 				newline: true,
@@ -616,7 +616,7 @@ var asANSITestCases = []struct {
 			{
 				nodes: []node{
 					{
-						blob: '0',
+						blob:  '0',
 						style: style(0),
 					},
 				},
@@ -625,19 +625,7 @@ var asANSITestCases = []struct {
 			{
 				nodes: []node{
 					{
-						blob: '1',
-						style: style(0),
-					},
-				},
-				newline: true,
-			},
-			{
-				newline: true,
-			},
-			{
-				nodes: []node{
-					{
-						blob: '2',
+						blob:  '1',
 						style: style(0),
 					},
 				},
@@ -647,12 +635,9 @@ var asANSITestCases = []struct {
 				newline: true,
 			},
 			{
-				newline: true,
-			},
-			{
 				nodes: []node{
 					{
-						blob: '3',
+						blob:  '2',
 						style: style(0),
 					},
 				},
@@ -665,12 +650,9 @@ var asANSITestCases = []struct {
 				newline: true,
 			},
 			{
-				newline: true,
-			},
-			{
 				nodes: []node{
 					{
-						blob: '4',
+						blob:  '3',
 						style: style(0),
 					},
 				},
@@ -686,12 +668,30 @@ var asANSITestCases = []struct {
 				newline: true,
 			},
 			{
+				nodes: []node{
+					{
+						blob:  '4',
+						style: style(0),
+					},
+				},
+				newline: true,
+			},
+			{
+				newline: true,
+			},
+			{
+				newline: true,
+			},
+			{
+				newline: true,
+			},
+			{
 				newline: true,
 			},
 			{
 				nodes: []node{
 					{
-						blob: '5',
+						blob:  '5',
 						style: style(0),
 					},
 				},
@@ -716,32 +716,32 @@ var asANSITestCases = []struct {
 		want: "\n\n0\n1\n\n2\n\n\n3\n\n\n\n4\n\n\n\n\n5\n\n\n\n\n",
 	},
 	{
-		name:  "test plain text no newline",
+		name: "test plain text no newline",
 		input: []screenLine{
 			{
 				nodes: []node{
 					{
-						blob: '0',
+						blob:  '0',
 						style: style(0),
 					},
 					{
-						blob: '1',
+						blob:  '1',
 						style: style(0),
 					},
 					{
-						blob: '2',
+						blob:  '2',
 						style: style(0),
 					},
 					{
-						blob: '3',
+						blob:  '3',
 						style: style(0),
 					},
 					{
-						blob: '4',
+						blob:  '4',
 						style: style(0),
 					},
 					{
-						blob: '5',
+						blob:  '5',
 						style: style(0),
 					},
 				},
@@ -751,33 +751,33 @@ var asANSITestCases = []struct {
 		want: "012345",
 	},
 	{
-		name:  "test same style",
+		name: "test same style",
 		input: []screenLine{
 			{
 				nodes: []node{
 					{
-						blob: '0',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '0',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 					{
-						blob: '1',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '1',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 					{
-						blob: '2',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '2',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 					{
-						blob: '3',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '3',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 					{
-						blob: '4',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '4',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 					{
-						blob: '5',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '5',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 				},
 				newline: true,
@@ -788,12 +788,12 @@ var asANSITestCases = []struct {
 			{
 				nodes: []node{
 					{
-						blob: '6',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '6',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 					{
-						blob: '7',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '7',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 				},
 				newline: false,
@@ -801,11 +801,11 @@ var asANSITestCases = []struct {
 			{
 				nodes: []node{
 					{
-						blob: '8',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '8',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 					{
-						blob: '9',
+						blob:  '9',
 						style: sbBold,
 					},
 				},
@@ -815,16 +815,16 @@ var asANSITestCases = []struct {
 		want: "\u001b[38;2;;187;;45;1;4m012345\n\n678\u001b[;1m9\n",
 	},
 	{
-		name:  "test style reset",
+		name: "test style reset",
 		input: []screenLine{
 			{
 				nodes: []node{
 					{
-						blob: '0',
-						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45 << 24,
+						blob:  '0',
+						style: sbBold | sbUnderline | sbFGColor24bit | 0xbb00 | sbBGColorSGR | 45<<24,
 					},
 					{
-						blob: '1',
+						blob:  '1',
 						style: style(0),
 					},
 				},
@@ -833,32 +833,32 @@ var asANSITestCases = []struct {
 		want: "\u001b[38;2;;187;;45;1;4m0\u001b[m1",
 	},
 	{
-		name:  "test trim",
+		name: "test trim",
 		input: []screenLine{
 			{
 				nodes: []node{
 					{
-						blob: '0',
+						blob:  '0',
 						style: style(0),
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: style(0),
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: style(0),
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: sbFGColor24bit | 0xda_bbed,
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: sbItalic,
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: style(0),
 					},
 				},
@@ -867,11 +867,11 @@ var asANSITestCases = []struct {
 			{
 				nodes: []node{
 					{
-						blob: '1',
+						blob:  '1',
 						style: style(0),
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: style(0),
 					},
 				},
@@ -880,24 +880,11 @@ var asANSITestCases = []struct {
 			{
 				nodes: []node{
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: style(0),
 					},
 					{
-						blob: '1',
-						style: style(0),
-					},
-				},
-				newline: true,
-			},
-			{
-				nodes: []node{
-					{
-						blob: ' ',
-						style: style(0),
-					},
-					{
-						blob: ' ',
+						blob:  '1',
 						style: style(0),
 					},
 				},
@@ -906,19 +893,32 @@ var asANSITestCases = []struct {
 			{
 				nodes: []node{
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: style(0),
 					},
 					{
-						blob: '2',
+						blob:  ' ',
+						style: style(0),
+					},
+				},
+				newline: true,
+			},
+			{
+				nodes: []node{
+					{
+						blob:  ' ',
 						style: style(0),
 					},
 					{
-						blob: ' ',
+						blob:  '2',
 						style: style(0),
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
+						style: style(0),
+					},
+					{
+						blob:  ' ',
 						style: style(0),
 					},
 				},
@@ -927,19 +927,19 @@ var asANSITestCases = []struct {
 			{
 				nodes: []node{
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: style(0),
 					},
 					{
-						blob: ' ',
-						style: sbBGColorSGR | 45 << 24,
+						blob:  ' ',
+						style: sbBGColorSGR | 45<<24,
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: sbBold,
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: style(0),
 					},
 				},
@@ -949,56 +949,56 @@ var asANSITestCases = []struct {
 		want: "0\n1  1\n\n 2   \u001b[45m \n",
 	},
 	{
-		name:  "test style transform",
+		name: "test style transform",
 		input: []screenLine{
 			{
 				nodes: []node{
 					{
-						blob: '0',
+						blob:  '0',
 						style: style(0),
 					},
 					{
-						blob: '1',
+						blob:  '1',
 						style: sbBold,
 					},
 					{
-						blob: '2',
+						blob:  '2',
 						style: sbBold | sbBlink,
 					},
 					{
-						blob: '3',
+						blob:  '3',
 						style: sbBold | sbBlink | sbFGColorSGR | 31,
 					},
 					{
-						blob: '4',
+						blob:  '4',
 						style: sbBold | sbBlink | sbFGColorSGR | 31,
 					},
 					{
-						blob: ' ',
-						style: sbItalic | sbFaint | sbFGColor24bit | 0x0000_00da_bbed | sbBGColor8bit | 195 << 24,
+						blob:  ' ',
+						style: sbItalic | sbFaint | sbFGColor24bit | 0x0000_00da_bbed | sbBGColor8bit | 195<<24,
 					},
 					{
-						blob: '5',
+						blob:  '5',
 						style: sbBold | sbBlink | sbFGColorSGR | 31,
 					},
 					{
-						blob: ' ',
+						blob:  ' ',
 						style: sbItalic | sbFaint | sbFGColorSGR | 31,
 					},
 					{
-						blob: '6',
+						blob:  '6',
 						style: sbBold | sbFGColor24bit | 31,
 					},
 					{
-						blob: '7',
+						blob:  '7',
 						style: sbBold | sbFGColor24bit | 31,
 					},
 					{
-						blob: '8',
+						blob:  '8',
 						style: sbBold | sbFGColor8bit | 31,
 					},
 					{
-						blob: '9',
+						blob:  '9',
 						style: sbItalic,
 					},
 				},
@@ -1007,94 +1007,92 @@ var asANSITestCases = []struct {
 			{
 				nodes: []node{
 					{
-						blob: 'a',
-						style: sbItalic | sbBGColor8bit | 55 << 24,
+						blob:  'a',
+						style: sbItalic | sbBGColor8bit | 55<<24,
 					},
 					{
-						blob: 'b',
-						style: sbItalic | sbStrike | sbBGColor8bit | 55 << 24,
+						blob:  'b',
+						style: sbItalic | sbStrike | sbBGColor8bit | 55<<24,
 					},
 					{
-						blob: 'c',
-						style: sbItalic | sbBGColor8bit | 55 << 24,
+						blob:  'c',
+						style: sbItalic | sbBGColor8bit | 55<<24,
 					},
 				},
 			},
 		},
-		want: (
-			"0\u001b[1m1\u001b[5m2\u001b[31m34\u001b[48;5;195m \u001b[49m5 " +
+		want: ("0\u001b[1m1\u001b[5m2\u001b[31m34\u001b[48;5;195m \u001b[49m5 " +
 			"\u001b[38;2;;;31;25m67\u001b[38;5;31m8\u001b[;3m9\n\u001b[48;5;55ma" +
 			"\u001b[9mb\u001b[29mc"),
 	},
 	{
-		name:  "test bold and faint",
+		name: "test bold and faint",
 		input: []screenLine{
 			{
 				nodes: []node{
 					{
-						blob: '0',
+						blob:  '0',
 						style: style(0),
 					},
 					{
-						blob: '1',
+						blob:  '1',
 						style: sbBold,
 					},
 					{
-						blob: '2',
+						blob:  '2',
 						style: sbFaint,
 					},
 					{
-						blob: '3',
+						blob:  '3',
 						style: sbBold,
 					},
 					{
-						blob: '4',
+						blob:  '4',
 						style: style(0),
 					},
 					{
-						blob: '5',
+						blob:  '5',
 						style: sbFaint,
 					},
 					{
-						blob: '6',
+						blob:  '6',
 						style: style(0),
 					},
 					{
-						blob: '7',
+						blob:  '7',
 						style: sbFaint | sbFGColor24bit | 0x0000_00da_bbed,
 					},
 					{
-						blob: '8',
+						blob:  '8',
 						style: sbBold | sbFGColor24bit | 0x0000_00da_bbed,
 					},
 					{
-						blob: '9',
+						blob:  '9',
 						style: sbFGColor24bit | 0x0000_00da_bbed,
 					},
 					{
-						blob: 'a',
+						blob:  'a',
 						style: sbBold | sbFGColor24bit | 0x0000_00da_bbed,
 					},
 					{
-						blob: 'b',
+						blob:  'b',
 						style: sbFaint | sbFGColor24bit | 0x0000_00da_bbed,
 					},
 					{
-						blob: 'c',
+						blob:  'c',
 						style: sbFGColor24bit | 0x0000_00da_bbed,
 					},
 				},
 			},
 		},
-		want: (
-			"0\u001b[1m1\u001b[2m2\u001b[1m3\u001b[m4\u001b[2m5" +
+		want: ("0\u001b[1m1\u001b[2m2\u001b[1m3\u001b[m4\u001b[2m5" +
 			"\u001b[m6\u001b[38;2;218;187;237;2m7\u001b[1m8\u001b[22m9" +
 			"\u001b[1ma\u001b[2mb\u001b[22mc"),
 	},
 	{
 		name: "Test leading whitespace with no newline",
 		want: " a",
-		input: []screenLine {
+		input: []screenLine{
 			{
 				newline: false,
 				nodes: []node{
@@ -1111,7 +1109,7 @@ var asANSITestCases = []struct {
 	{
 		name: "Test whitespace with no newline",
 		want: " ",
-		input: []screenLine {
+		input: []screenLine{
 			{
 				newline: false,
 				nodes: []node{
@@ -1125,7 +1123,7 @@ var asANSITestCases = []struct {
 	{
 		name: "Test trailing whitespace with no newline",
 		want: "a ",
-		input: []screenLine {
+		input: []screenLine{
 			{
 				newline: false,
 				nodes: []node{
@@ -1142,7 +1140,7 @@ var asANSITestCases = []struct {
 	{
 		name: "Test surrounding whitespace with no newline",
 		want: " a ",
-		input: []screenLine {
+		input: []screenLine{
 			{
 				newline: false,
 				nodes: []node{
@@ -1169,6 +1167,21 @@ func TestAsANSI(t *testing.T) {
 
 			if diff := cmp.Diff(got, want); diff != "" {
 				t.Errorf("(&Screen{screen: %v}).AsAnsi() diff (-got +want):\n%s", c.input, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkAsANSI(b *testing.B) {
+	for _, c := range asANSITestCases {
+		b.Run(c.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				got, _ := (&Screen{screen: c.input}).AsANSI()
+				want := c.want
+
+				if len(got) != len(want) {
+					b.Errorf("(&Screen{screen: %v}).AsAnsi() length mismatch got %d want %d", c.input, len(got), len(want))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This showed up in CPU profiles when apps were using 100% of CPU, and this function was using up to 4%. This code doesn't do anything bad or computationally expensive, so the optimizations are mostly about reducing allocations.

I added a benchmark that uses the same data as the tests. I would love a more realistic benchmark, but I wasn't sure how to set that up.

Benchmark results:
```
goos: linux
goarch: amd64
pkg: github.com/buildkite/terminal-to-html/v3
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                                                      │     base      │             afterlazy2              │
                                                      │    sec/op     │    sec/op     vs base               │
AsANSI/test_plain_text-24                                130.8n ±  6%   103.8n ± 10%  -20.64% (p=0.001 n=7)
AsANSI/test_single_blank_line-24                         31.39n ±  5%   31.82n ±  2%        ~ (p=0.097 n=7)
AsANSI/test_two_blank_lines-24                           42.47n ±  2%   42.66n ±  3%        ~ (p=0.925 n=7)
AsANSI/test_new_lines-24                                 559.4n ±  1%   480.7n ±  5%  -14.07% (p=0.001 n=7)
AsANSI/test_plain_text_no_newline-24                    105.10n ± 12%   73.06n ±  1%  -30.49% (p=0.001 n=7)
AsANSI/test_same_style-24                               2214.0n ±  5%   493.1n ±  3%  -77.73% (p=0.001 n=7)
AsANSI/test_style_reset-24                               450.1n ±  1%   208.9n ± 12%  -53.59% (p=0.001 n=7)
AsANSI/test_trim-24                                      503.1n ±  5%   324.0n ±  3%  -35.60% (p=0.001 n=7)
AsANSI/test_style_transform-24                           2.535µ ±  1%   1.400µ ±  1%  -44.77% (p=0.001 n=7)
AsANSI/test_bold_and_faint-24                            1.882µ ±  3%   1.087µ ±  2%  -42.24% (p=0.001 n=7)
AsANSI/Test_leading_whitespace_with_no_newline-24        63.37n ±  3%   37.69n ±  2%  -40.52% (p=0.001 n=7)
AsANSI/Test_whitespace_with_no_newline-24                53.65n ±  1%   34.57n ±  1%  -35.56% (p=0.001 n=7)
AsANSI/Test_trailing_whitespace_with_no_newline-24       63.71n ±  4%   37.74n ±  1%  -40.76% (p=0.001 n=7)
AsANSI/Test_surrounding_whitespace_with_no_newline-24    73.57n ±  1%   57.84n ± 12%  -21.38% (p=0.001 n=7)
geomean                                                  212.8n         135.7n        -36.25%

                                                      │     base     │              afterlazy2               │
                                                      │     B/op     │     B/op      vs base                 │
AsANSI/test_plain_text-24                                 120.0 ± 0%     120.0 ± 0%        ~ (p=1.000 n=7) ¹
AsANSI/test_single_blank_line-24                          8.000 ± 0%     8.000 ± 0%        ~ (p=1.000 n=7) ¹
AsANSI/test_two_blank_lines-24                            8.000 ± 0%     8.000 ± 0%        ~ (p=1.000 n=7) ¹
AsANSI/test_new_lines-24                                  248.0 ± 0%     152.0 ± 0%  -38.71% (p=0.001 n=7)
AsANSI/test_plain_text_no_newline-24                      112.0 ± 0%     112.0 ± 0%        ~ (p=1.000 n=7) ¹
AsANSI/test_same_style-24                                4560.0 ± 0%     784.0 ± 0%  -82.81% (p=0.001 n=7)
AsANSI/test_style_reset-24                                816.0 ± 0%     352.0 ± 0%  -56.86% (p=0.001 n=7)
AsANSI/test_trim-24                                       592.0 ± 0%     408.0 ± 0%  -31.08% (p=0.001 n=7)
AsANSI/test_style_transform-24                          4.406Ki ± 0%   2.742Ki ± 0%  -37.77% (p=0.001 n=7)
AsANSI/test_bold_and_faint-24                           3.102Ki ± 0%   1.883Ki ± 0%  -39.29% (p=0.001 n=7)
AsANSI/Test_leading_whitespace_with_no_newline-24         48.00 ± 0%     16.00 ± 0%  -66.67% (p=0.001 n=7)
AsANSI/Test_whitespace_with_no_newline-24                 32.00 ± 0%     16.00 ± 0%  -50.00% (p=0.001 n=7)
AsANSI/Test_trailing_whitespace_with_no_newline-24        48.00 ± 0%     16.00 ± 0%  -66.67% (p=0.001 n=7)
AsANSI/Test_surrounding_whitespace_with_no_newline-24     64.00 ± 0%     64.00 ± 0%        ~ (p=1.000 n=7) ¹
geomean                                                   177.9          105.4       -40.75%
¹ all samples are equal

                                                      │    base     │             afterlazy2              │
                                                      │  allocs/op  │ allocs/op   vs base                 │
AsANSI/test_plain_text-24                                4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=7) ¹
AsANSI/test_single_blank_line-24                         1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=7) ¹
AsANSI/test_two_blank_lines-24                           1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=7) ¹
AsANSI/test_new_lines-24                                 21.00 ± 0%   15.00 ± 0%  -28.57% (p=0.001 n=7)
AsANSI/test_plain_text_no_newline-24                     3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=7) ¹
AsANSI/test_same_style-24                                68.00 ± 0%   19.00 ± 0%  -72.06% (p=0.001 n=7)
AsANSI/test_style_reset-24                              15.000 ± 0%   8.000 ± 0%  -46.67% (p=0.001 n=7)
AsANSI/test_trim-24                                      19.00 ± 0%   13.00 ± 0%  -31.58% (p=0.001 n=7)
AsANSI/test_style_transform-24                           93.00 ± 0%   52.00 ± 0%  -44.09% (p=0.001 n=7)
AsANSI/test_bold_and_faint-24                            76.00 ± 0%   48.00 ± 0%  -36.84% (p=0.001 n=7)
AsANSI/Test_leading_whitespace_with_no_newline-24        3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.001 n=7)
AsANSI/Test_whitespace_with_no_newline-24                3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.001 n=7)
AsANSI/Test_trailing_whitespace_with_no_newline-24       3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.001 n=7)
AsANSI/Test_surrounding_whitespace_with_no_newline-24    3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=7) ¹
geomean                                                  7.745        5.467       -29.41%
¹ all samples are equal
```